### PR TITLE
Refactor input schema for creating a PR in Azure DevOps

### DIFF
--- a/src/actions/run/pullRequestAzureRepo.ts
+++ b/src/actions/run/pullRequestAzureRepo.ts
@@ -32,57 +32,51 @@ export const pullRequestAzureRepoAction = (options: {
     description: 'Create a PR to a repository in Azure DevOps.',
     schema: {
       input: {
-        required: [],
         type: 'object',
+        required: ['repoId', 'title'],
         properties: {
-          input: {
-            type: 'object',
-            required: ['repoId', 'title'],
-            properties: {
-              organization: {
-                title: 'Organization Name',
-                type: 'string',
-                description: 'The name of the organization in Azure DevOps.',
-              },
-              sourceBranch: {
-                title: 'Source Branch',
-                type: 'string',
-                description: 'The branch to merge into the source.',
-              },
-              targetBranch: {
-                title: 'Target Branch',
-                type: 'string',
-                description: "The branch to merge into (default: main).",
-              },
-              title: {
-                title: 'Title',
-                description: 'The title of the pull request.',
-                type: 'string',
-              },
-              repoId: {
-                title: 'Remote Repo ID',
-                description: 'Repo ID of the pull request.',
-                type: 'string',
-              },
-              project: {
-                title: 'ADO Project',
-                description: 'The Project in Azure DevOps.',
-                type: 'string',
-              },
-              supportsIterations: {
-                title: 'Supports Iterations',
-                description: 'Whether or not the PR supports interations.',
-                type: 'boolean',
-              },
-              token: {
-                title: 'Authenticatino Token',
-                type: 'string',
-                description: 'The token to use for authorization.',
-              },
-            }
+          organization: {
+            title: 'Organization Name',
+            type: 'string',
+            description: 'The name of the organization in Azure DevOps.',
           },
-        },
-      },
+          sourceBranch: {
+            title: 'Source Branch',
+            type: 'string',
+            description: 'The branch to merge into the source.',
+          },
+          targetBranch: {
+            title: 'Target Branch',
+            type: 'string',
+            description: "The branch to merge into (default: main).",
+          },
+          title: {
+            title: 'Title',
+            description: 'The title of the pull request.',
+            type: 'string',
+          },
+          repoId: {
+            title: 'Remote Repo ID',
+            description: 'Repo ID of the pull request.',
+            type: 'string',
+          },
+          project: {
+            title: 'ADO Project',
+            description: 'The Project in Azure DevOps.',
+            type: 'string',
+          },
+          supportsIterations: {
+            title: 'Supports Iterations',
+            description: 'Whether or not the PR supports interations.',
+            type: 'boolean',
+          },
+          token: {
+            title: 'Authenticatino Token',
+            type: 'string',
+            description: 'The token to use for authorization.',
+          },
+        }
+      }
     },
     async handler(ctx) {
       const { title, repoId, project, supportsIterations } = ctx.input;
@@ -122,4 +116,3 @@ export const pullRequestAzureRepoAction = (options: {
     },
   });
 };
-


### PR DESCRIPTION
Description:

This pull request simplifies the input schema for creating a PR in an Azure DevOps repository.

Changes:

Removed an unnecessary layer in the input schema of the PR creation functionality.
The input parameters repoId and title remain required.
The remaining parameters including organization, sourceBranch, targetBranch, project, supportsIterations, and token are optional and can be provided according to the requirements of the PR.
Before:

The input schema was nested inside another input object, which was causing an unnecessary level of complexity when reading the actions section. The original schema structure was:

`schema: {
  input: {
    required: [],
    type: 'object',
    properties: {
      input: {
        // Rest of schema...
      }
    }
  }
}`

After:

The updated schema simplifies this structure by removing the additional input layer, making it more straightforward to use:

`schema: {
  input: {
    // Rest of schema...
  }
}`


This refactor aims to improve code readability and ease of use when creating a PR in an Azure DevOps repository.